### PR TITLE
Add input text field resizing

### DIFF
--- a/Source/Repl/CSharpRepl.cs
+++ b/Source/Repl/CSharpRepl.cs
@@ -293,16 +293,39 @@ public partial class CSharpRepl : Tab
 
     public override bool CanBeVisible() => true;
 
+    private float inputTextHeight = 110f;
+    private bool resizingText;
+    private float lastMouseY;
+
     public override void Render(Level? _)
     {
         bool runScript = ImGui.InputTextMultiline(
             " Script",
             ref ScriptText,
             0x10000,
-            -Vector2.UnitX,
+            new Vector2(-1f, inputTextHeight),
             InputTextFlags,
             TextInputDelegate
         );
+
+        // input text field resizing
+        ImGui.Selectable("", false, ImGuiSelectableFlags.None, new Vector2(0f, 2f));
+        if (ImGui.IsItemClicked())
+        {
+            resizingText = true;
+        }
+        else if (!ImGui.IsMouseDown(ImGuiMouseButton.Left))
+        {
+            resizingText = false;
+        }
+        // Imgui.GetMouseDragDelta() exists, but doing this manually is more responsive
+        float currentMouseY = ImGui.GetMousePos().Y;
+        if (resizingText)
+        {
+            inputTextHeight += currentMouseY - lastMouseY;
+            inputTextHeight = Math.Max(inputTextHeight, 10f);
+        }
+        lastMouseY = currentMouseY;
 
         StringBuilder builder = new();
         foreach (ReplSubmission submission in Submissions)


### PR DESCRIPTION
https://github.com/user-attachments/assets/b02790d1-4862-4262-a8b2-6415cac45581

Adds resizing to the input text field so you can see more than ~8 lines at once.

Internally, it works by adding a thin `Selectable` widget. When clicked, it enters a sort of resizing mode, during which the text field's height is changed according to mouse movement until click is released.
- As far as I can tell, `Imgui.IsItemClicked()` and similar methods just check the last-added widget, which is convenient.
- There's no need for any sort of translation - passing a positive number for one of the size vector components just acts as a size in pixels.

Minor notes:
- The default of 110 is just to match the current size, but you can obviously feel free to change that if you want. Maybe it could be saved in settings also?
- Resizing it to be too tall (taller than the current window) shrinks the output box to a point where it's unreadable, but I'm not sure what to do about that without _also_ dynamically calculating the output box's size and it's probably fine either way?